### PR TITLE
Change binary path argument to a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $db = new Phlib\Db\Adapter([
 
 $schemaChange = new \Phlib\SchemaChange\SchemaChange(
     $db,
-    new \Phlib\SchemaChange\OnlineChangeRunner(['/usr/local/bin/pt-online-schema-change'])
+    new \Phlib\SchemaChange\OnlineChangeRunner('/usr/local/bin/pt-online-schema-change')
 );
 
 $schemaChange->mapNames(new class implements \Phlib\SchemaChange\NameMapper {

--- a/src/OnlineChangeRunner.php
+++ b/src/OnlineChangeRunner.php
@@ -10,11 +10,11 @@ use Symfony\Component\Process\Process;
 class OnlineChangeRunner
 {
     /**
-     * @var array
+     * @var string
      */
     private $binPath;
 
-    public function __construct(array $binPath)
+    public function __construct(string $binPath)
     {
         $this->binPath = $binPath;
     }
@@ -22,8 +22,7 @@ class OnlineChangeRunner
     public function execute(array $dbConfig, OnlineChange $onlineChange): void
     {
         $cmd = array_merge(
-            $this->binPath,
-            [$this->buildDsn($dbConfig, $onlineChange->getName())],
+            [$this->binPath, $this->buildDsn($dbConfig, $onlineChange->getName())],
             $this->getOptions($onlineChange),
             ['--alter', $onlineChange->toOnlineAlter()]
         );


### PR DESCRIPTION
This was originally an array argument due to a convention from a previous project of always using an array for binary paths when using Symfony process, so that it is possible to specify an interpreter/script combination.

This doesn't really make sense for the online schema change binary, and just adds confusion for the public API, so better to simplify it to a string.