### PR TITLE
Add names keys functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 /composer.lock
 .phpunit.result.cache
+.idea

--- a/src/Table/Alter.php
+++ b/src/Table/Alter.php
@@ -96,6 +96,12 @@ class Alter extends Create implements OnlineChange
         return $this;
     }
 
+    public function removeKey(string $keyName): self
+    {
+        $this->removeIndexes[] = $keyName;
+        return $this;
+    }
+
     public function force(): self
     {
         $this->force = true;

--- a/src/Table/Create.php
+++ b/src/Table/Create.php
@@ -48,6 +48,14 @@ class Create extends Table
         return $index;
     }
 
+    public function addKey(string $name, string ...$columns): Index
+    {
+        $index = new Index($this->formatter, $this->table, ...$columns);
+        $index->name($name);
+        $this->addIndexes[] = $index;
+        return $index;
+    }
+
     public function addPrimary(string ...$columns): self
     {
         $this->primary = $columns;


### PR DESCRIPTION
The standard addIndex method doesn't allow to specify the name of the key.

It doesn't seem to be possible to change the addIndex signature to provider backward compatibility (it uses the (...$columns) syntax).

Instead this pull requests adds two new methods:
 - addKey($name, $columns)
 - removeKey($name)
